### PR TITLE
Dates unified

### DIFF
--- a/src/main/java/pl/ismop/web/client/IsmopConverter.java
+++ b/src/main/java/pl/ismop/web/client/IsmopConverter.java
@@ -1,0 +1,20 @@
+package pl.ismop.web.client;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.inject.Singleton;
+
+import java.util.Date;
+
+@Singleton
+public class IsmopConverter {
+    private final DateTimeFormat dateTimeFormat =
+            DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.ISO_8601);
+
+    public String format(Date date) {
+        return dateTimeFormat.format(date);
+    }
+
+    public Date parse(String dateString) {
+        return dateTimeFormat.parse(dateString);
+    }
+}

--- a/src/main/java/pl/ismop/web/client/dap/DapController.java
+++ b/src/main/java/pl/ismop/web/client/dap/DapController.java
@@ -10,11 +10,10 @@ import javax.inject.Inject;
 import org.fusesource.restygwt.client.Method;
 import org.fusesource.restygwt.client.MethodCallback;
 
-import com.google.gwt.i18n.client.DateTimeFormat;
-import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.google.gwt.user.client.Window;
 import com.google.inject.Singleton;
 
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.dap.context.Context;
 import pl.ismop.web.client.dap.context.ContextService;
 import pl.ismop.web.client.dap.context.ContextsResponse;
@@ -60,11 +59,10 @@ import pl.ismop.web.client.error.ErrorCallback;
 import pl.ismop.web.client.error.ErrorDetails;
 import pl.ismop.web.client.error.ErrorUtil;
 import pl.ismop.web.client.hypgen.Experiment;
-import pl.ismop.web.client.widgets.delegator.ContextsCallback;
-import pl.ismop.web.client.widgets.delegator.ParametersCallback;
 
 @Singleton
 public class DapController {
+	private final IsmopConverter converter;
 	private ExperimentService leveeExperimentService;
 	private ErrorUtil errorUtil;
 	private LeveeService leveeService;
@@ -162,7 +160,7 @@ public class DapController {
 	public DapController(ErrorUtil errorUtil, LeveeService leveeService, SensorService sensorService, MeasurementService measurementService,
 			SectionService sectionService, ThreatAssessmentService experimentService, ResultService resultService, ProfileService profileService,
 			DeviceService deviceService, DeviceAggregationService deviceAggregationService, ParameterService parameterService, ContextService contextService,
-			TimelineService timelineService, ExperimentService leveeExperimentService) {
+			TimelineService timelineService, ExperimentService leveeExperimentService, IsmopConverter converter) {
 		this.errorUtil = errorUtil;
 		this.leveeService = leveeService;
 		this.sensorService = sensorService;
@@ -177,6 +175,7 @@ public class DapController {
 		this.contextService = contextService;
 		this.timelineService = timelineService;
 		this.leveeExperimentService = leveeExperimentService;
+		this.converter = converter;
 	}
 	
 	public void getLevees(final LeveesCallback callback) {	
@@ -249,14 +248,14 @@ public class DapController {
 	}
 
 	public void getMeasurements(String timelineId, Date startDate, Date endDate, final MeasurementsCallback callback) {
-		String until = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(endDate);
-		String from = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(startDate);
+		String until = converter.format(endDate);
+		String from = converter.format(startDate);
 		measurementService.getMeasurements(timelineId, from, until, new MeasurementsRestCallback(callback));
 	}
 	
 	public void getMeasurementsWithQuantity(String timelineId, Date startDate, Date endDate, int quantity, final MeasurementsCallback callback) {
-		String until = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(endDate);
-		String from = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(startDate);
+		String until = converter.format(endDate);
+		String from = converter.format(startDate);
 		measurementService.getMeasurementsWithQuantity(timelineId, from, until, quantity, new MeasurementsRestCallback(callback));
 	}
 
@@ -279,10 +278,8 @@ public class DapController {
 	}
 
 	public void getLastMeasurements(List<String> timelineIds, Date date, final MeasurementsCallback callback) {
-		String until = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(date);
-		String from = DateTimeFormat.
-						getFormat(PredefinedFormat.ISO_8601).
-						format(new Date(date.getTime() - 1500_000L));
+		String until = converter.format(date);
+		String from = converter.format(new Date(date.getTime() - 1500_000L));
 
 		measurementService.getLastMeasurements(merge(timelineIds, ","), from, until,
 				new MeasurementsRestCallback(callback));
@@ -580,8 +577,8 @@ public class DapController {
 	}
 
 	public void getMeasurementsForTimelineIds(List<String> timelineIds, final MeasurementsCallback callback) {
-		String until = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(new Date());
-		String from = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(monthEarlier());
+		String until = converter.format(new Date());
+		String from = converter.format(monthEarlier());
 		measurementService.getMeasurements(merge(timelineIds, ","), from, until, new MethodCallback<MeasurementsResponse>() {
 			@Override
 			public void onFailure(Method method, Throwable exception) {
@@ -596,8 +593,8 @@ public class DapController {
 	}
 
 	public void getMeasurementsForTimelineIdsWithQuantity(List<String> timelineIds, int quantity, final MeasurementsCallback callback) {
-		String until = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(new Date());
-		String from = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(threeDaysEarlier());
+		String until = converter.format(new Date());
+		String from = converter.format(threeDaysEarlier());
 		measurementService.getMeasurementsWithQuantity(merge(timelineIds, ","), from, until, quantity, new MethodCallback<MeasurementsResponse>() {
 			@Override
 			public void onFailure(Method method, Throwable exception) {

--- a/src/main/java/pl/ismop/web/client/dap/experiment/Experiment.java
+++ b/src/main/java/pl/ismop/web/client/dap/experiment/Experiment.java
@@ -18,14 +18,10 @@ public class Experiment {
     private String description;
 
     @Json(name = "start_date")
-    private String start;
+    private Date start;
 
     @Json(name = "end_date")
-    private String end;
-
-    private Date startDate;
-
-    private Date endDate;
+    private Date end;
 
     @Json(name = "levee_id")
     private Integer leveeId;
@@ -56,22 +52,20 @@ public class Experiment {
         return description;
     }
 
-    public String getStart() {
+    public Date getStart() {
         return start;
     }
 
-    public void setStart(String start) {
+    public void setStart(Date start) {
         this.start = start;
-        this.startDate = format.parse(start);
     }
 
-    public String getEnd() {
+    public Date getEnd() {
         return end;
     }
 
-    public void setEnd(String end) {
+    public void setEnd(Date end) {
         this.end = end;
-        this.endDate = format.parse(end);
     }
 
     public Integer getLeveeId() {
@@ -88,14 +82,6 @@ public class Experiment {
 
     public void setTimelineIds(List<Integer> timelineIds) {
         this.timelineIds = timelineIds;
-    }
-
-    public Date getStartDate() {
-        return startDate;
-    }
-
-    public Date getEndDate() {
-        return endDate;
     }
 
     public void setSections(List<Section> sections) {

--- a/src/main/java/pl/ismop/web/client/dap/measurement/Measurement.java
+++ b/src/main/java/pl/ismop/web/client/dap/measurement/Measurement.java
@@ -3,13 +3,15 @@ package pl.ismop.web.client.dap.measurement;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.fusesource.restygwt.client.Json;
 
+import java.util.Date;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Measurement {
 	private String id;
 	
 	private double value;
 	
-	private String timestamp;
+	private Date timestamp;
 	
 	@Json(name = "timeline_id")
 	private String timelineId;
@@ -38,11 +40,11 @@ public class Measurement {
 		this.value = value;
 	}
 	
-	public String getTimestamp() {
+	public Date getTimestamp() {
 		return timestamp;
 	}
 	
-	public void setTimestamp(String timestamp) {
+	public void setTimestamp(Date timestamp) {
 		this.timestamp = timestamp;
 	}
 }

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
@@ -45,7 +45,7 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
     @Override
     public void setSelectedExperiment(Experiment experiment) {
         selectedExperiment = experiment;
-        getView().setInterval(experiment.getStartDate(), experiment.getEndDate());
+        getView().setInterval(experiment.getStart(), experiment.getEnd());
     }
 
     @Override
@@ -84,8 +84,8 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
             selectionManager.selectDevice(timeline.getParameter().getDevice());
         }
 
-        dapController.getMeasurements(idToTimeline.keySet(), selectedExperiment.getStartDate(),
-                selectedExperiment.getEndDate(), new DapController.MeasurementsCallback() {
+        dapController.getMeasurements(idToTimeline.keySet(), selectedExperiment.getStart(),
+                selectedExperiment.getEnd(), new DapController.MeasurementsCallback() {
             @Override
             public void processMeasurements(List<Measurement> measurements) {
                 getView().setSeries(map(measurements));

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
@@ -3,7 +3,6 @@ package pl.ismop.web.client.widgets.analysis.chart;
 import com.google.inject.Inject;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
-import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.IsmopProperties;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
@@ -23,7 +22,6 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
         implements IPanelContent<IChartView, MainEventBus>, IChartView.IChartPresenter {
     private final DapController dapController;
     private final IsmopProperties properties;
-    private final IsmopConverter formatter;
     private Experiment selectedExperiment;
     private List<Timeline> timelines;
     ChartMessages messages;
@@ -31,10 +29,9 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
     private ChartWizardPresenter wizard;
 
     @Inject
-    public ChartPresenter(DapController dapController, IsmopProperties properties, IsmopConverter formatter) {
+    public ChartPresenter(DapController dapController, IsmopProperties properties) {
         this.dapController = dapController;
         this.properties = properties;
-        this.formatter = formatter;
     }
 
     @Override

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
@@ -1,10 +1,9 @@
 package pl.ismop.web.client.widgets.analysis.chart;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.inject.Inject;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.IsmopProperties;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
@@ -24,6 +23,7 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
         implements IPanelContent<IChartView, MainEventBus>, IChartView.IChartPresenter {
     private final DapController dapController;
     private final IsmopProperties properties;
+    private final IsmopConverter formatter;
     private Experiment selectedExperiment;
     private List<Timeline> timelines;
     ChartMessages messages;
@@ -31,9 +31,10 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
     private ChartWizardPresenter wizard;
 
     @Inject
-    public ChartPresenter(DapController dapController, IsmopProperties properties) {
+    public ChartPresenter(DapController dapController, IsmopProperties properties, IsmopConverter formatter) {
         this.dapController = dapController;
         this.properties = properties;
+        this.formatter = formatter;
     }
 
     @Override
@@ -91,7 +92,6 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
             }
 
             private Map<Timeline, List<DateChartPoint>> map(List<Measurement> measurements) {
-                DateTimeFormat format = DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.ISO_8601);
                 Map<Timeline, List<DateChartPoint>> timelineToMeasurements = new HashMap<>();
                 for (Measurement measurement : measurements) {
                     Timeline timeline = idToTimeline.get(measurement.getTimelineId());
@@ -101,7 +101,7 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
                         timelineToMeasurements.put(timeline, timelineMeasurements);
                     }
 
-                    Date date = format.parse(measurement.getTimestamp());
+                    Date date = formatter.parse(measurement.getTimestamp());
                     timelineMeasurements.add(new DateChartPoint(date, measurement.getValue()));
                 }
 

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/chart/ChartPresenter.java
@@ -101,8 +101,7 @@ public class ChartPresenter extends BasePresenter<IChartView, MainEventBus>
                         timelineToMeasurements.put(timeline, timelineMeasurements);
                     }
 
-                    Date date = formatter.parse(measurement.getTimestamp());
-                    timelineMeasurements.add(new DateChartPoint(date, measurement.getValue()));
+                    timelineMeasurements.add(new DateChartPoint(measurement.getTimestamp(), measurement.getValue()));
                 }
 
                 return timelineToMeasurements;

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/comparison/ComparisonPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/comparison/ComparisonPresenter.java
@@ -115,8 +115,8 @@ public class ComparisonPresenter extends BasePresenter<IComparisonView, MainEven
     private void updateSliderDates() {
         if (selectedExperiment != null) {
             Date previousDate = sliderPresenter.getSelectedDate();
-            sliderPresenter.setStartDate(selectedExperiment.getStartDate());
-            sliderPresenter.setEndDate(selectedExperiment.getEndDate());
+            sliderPresenter.setStartDate(selectedExperiment.getStart());
+            sliderPresenter.setEndDate(selectedExperiment.getEnd());
             if (!previousDate.equals(sliderPresenter.getSelectedDate())) {
                 eventBus.dateChanged(sliderPresenter.getSelectedDate());
             }

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
@@ -183,12 +183,12 @@ public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanel
             long diff = 0;
             if(entry.getValue().size() > 0) {
                 diff = converter.parse(entry.getValue().get(0).getTimestamp()).getTime() -
-                        selectedExperiment.getStartDate().getTime();
+                        selectedExperiment.getStart().getTime();
             }
 
             for (Measurement measurement : entry.getValue()) {
                 long time = converter.parse(measurement.getTimestamp()).getTime() - diff;
-                if (time > selectedExperiment.getEndDate().getTime()) {
+                if (time > selectedExperiment.getEnd().getTime()) {
                     GWT.log("Warning experiment water wave is longer then experiment");
                     break;
                 }

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
@@ -1,12 +1,10 @@
 package pl.ismop.web.client.widgets.analysis.sidepanel;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.inject.Inject;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
 import org.moxieapps.gwt.highcharts.client.*;
-import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.IsmopProperties;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
@@ -29,7 +27,6 @@ import java.util.*;
 public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanelView, MainEventBus> implements IAnalysisSidePanelPresenter {
     private final DapController dapController;
     private final IsmopProperties properties;
-    private final IsmopConverter converter;
     private PlotLine currentTimePlotLine;
 
     private MapPresenter miniMap;
@@ -43,10 +40,9 @@ public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanel
     private Profile shownProfile;
 
     @Inject
-    public AnalysisSidePanelPresenter(DapController dapController, IsmopProperties properties, IsmopConverter converter) {
+    public AnalysisSidePanelPresenter(DapController dapController, IsmopProperties properties) {
         this.dapController = dapController;
         this.properties = properties;
-        this.converter = converter;
     }
 
     public void init() {

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
@@ -6,6 +6,7 @@ import com.google.inject.Inject;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
 import org.moxieapps.gwt.highcharts.client.*;
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.IsmopProperties;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
@@ -28,6 +29,7 @@ import java.util.*;
 public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanelView, MainEventBus> implements IAnalysisSidePanelPresenter {
     private final DapController dapController;
     private final IsmopProperties properties;
+    private final IsmopConverter converter;
     private PlotLine currentTimePlotLine;
 
     private MapPresenter miniMap;
@@ -41,9 +43,10 @@ public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanel
     private Profile shownProfile;
 
     @Inject
-    public AnalysisSidePanelPresenter(DapController dapController, IsmopProperties properties) {
+    public AnalysisSidePanelPresenter(DapController dapController, IsmopProperties properties, IsmopConverter converter) {
         this.dapController = dapController;
         this.properties = properties;
+        this.converter = converter;
     }
 
     public void init() {
@@ -170,7 +173,6 @@ public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanel
 
     private void showExperimentWaveShape(Map<Parameter, List<Measurement>> series) {
         waterWave.removeAllSeries();
-        DateTimeFormat format = DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.ISO_8601);
         Parameter parameter = null;
         for (Map.Entry<Parameter, List<Measurement>> entry : series.entrySet()) {
             parameter = entry.getKey();
@@ -180,12 +182,12 @@ public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanel
 
             long diff = 0;
             if(entry.getValue().size() > 0) {
-                diff = format.parse(entry.getValue().get(0).getTimestamp()).getTime() -
+                diff = converter.parse(entry.getValue().get(0).getTimestamp()).getTime() -
                         selectedExperiment.getStartDate().getTime();
             }
 
             for (Measurement measurement : entry.getValue()) {
-                long time = format.parse(measurement.getTimestamp()).getTime() - diff;
+                long time = converter.parse(measurement.getTimestamp()).getTime() - diff;
                 if (time > selectedExperiment.getEndDate().getTime()) {
                     GWT.log("Warning experiment water wave is longer then experiment");
                     break;

--- a/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/analysis/sidepanel/AnalysisSidePanelPresenter.java
@@ -182,12 +182,11 @@ public class AnalysisSidePanelPresenter extends BasePresenter<IAnalysisSidePanel
 
             long diff = 0;
             if(entry.getValue().size() > 0) {
-                diff = converter.parse(entry.getValue().get(0).getTimestamp()).getTime() -
-                        selectedExperiment.getStart().getTime();
+                diff = entry.getValue().get(0).getTimestamp().getTime() - selectedExperiment.getStart().getTime();
             }
 
             for (Measurement measurement : entry.getValue()) {
-                long time = converter.parse(measurement.getTimestamp()).getTime() - diff;
+                long time = measurement.getTimestamp().getTime() - diff;
                 if (time > selectedExperiment.getEnd().getTime()) {
                     GWT.log("Warning experiment water wave is longer then experiment");
                     break;

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/DataFetcher.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/DataFetcher.java
@@ -3,8 +3,6 @@ package pl.ismop.web.client.widgets.monitoring.fibre;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.i18n.client.DateTimeFormat;
-import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.dap.DapController;
 import pl.ismop.web.client.dap.device.Device;
 import pl.ismop.web.client.dap.deviceaggregation.DeviceAggregate;

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/DataFetcher.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/DataFetcher.java
@@ -4,6 +4,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.dap.DapController;
 import pl.ismop.web.client.dap.device.Device;
 import pl.ismop.web.client.dap.deviceaggregation.DeviceAggregate;
@@ -22,7 +23,6 @@ import pl.ismop.web.client.widgets.delegator.TimelinesCallback;
 import java.util.*;
 
 public class DataFetcher implements IDataFetcher {
-
     private abstract class DeviceAggregationsCallback extends ErrorCallbackDelegator implements DapController.DeviceAggregatesCallback {
         public DeviceAggregationsCallback(ErrorCallback callback) {
             super(callback);
@@ -41,6 +41,7 @@ public class DataFetcher implements IDataFetcher {
         }
     }
 
+    private final IsmopConverter converter;
     private final Levee levee;
     private final DapController dapController;
     private final String contextId;
@@ -53,10 +54,11 @@ public class DataFetcher implements IDataFetcher {
     private boolean initialized = false;
     private String yAxisTitle;
 
-    public DataFetcher(DapController dapController, Levee levee) {
+    public DataFetcher(DapController dapController, IsmopConverter converter, Levee levee) {
         this.dapController = dapController;
         this.levee = levee;
         this.contextId = "1";
+        this.converter = converter;
     }
 
     @Override
@@ -282,7 +284,6 @@ public class DataFetcher implements IDataFetcher {
         dapController.getMeasurements(timelineIds, startDate, endDate, new MeasurementsCallback(callback) {
             @Override
             public void processMeasurements(List<Measurement> measurements) {
-                DateTimeFormat format = DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.ISO_8601);
                 Map<Device, List<DateChartPoint>> results = new HashMap<Device, List<DateChartPoint>>();
                 for (Measurement m : measurements) {
                     Device device = timelineIdToDevice.get(m.getTimelineId());
@@ -291,7 +292,7 @@ public class DataFetcher implements IDataFetcher {
                         series = new ArrayList<DateChartPoint>();
                         results.put(device, series);
                     }
-                    Date date = format.parse(m.getTimestamp());
+                    Date date = converter.parse(m.getTimestamp());
                     series.add(new DateChartPoint(date, m.getValue()));
                 }
                 callback.series(results);
@@ -318,10 +319,9 @@ public class DataFetcher implements IDataFetcher {
                 (timelineIdToDevice.inverse().get(device), startDate, endDate, new MeasurementsCallback(callback) {
                     @Override
                     public void processMeasurements(List<Measurement> measurements) {
-                        DateTimeFormat format = DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.ISO_8601);
                         List<DateChartPoint> points = new ArrayList<>();
                         for (Measurement m : measurements) {
-                            Date date = format.parse(m.getTimestamp());
+                            Date date = converter.parse(m.getTimestamp());
                             points.add(new DateChartPoint(date, m.getValue()));
                         }
                         callback.series(points);

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/DataFetcher.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/DataFetcher.java
@@ -41,7 +41,6 @@ public class DataFetcher implements IDataFetcher {
         }
     }
 
-    private final IsmopConverter converter;
     private final Levee levee;
     private final DapController dapController;
     private final String contextId;
@@ -54,11 +53,10 @@ public class DataFetcher implements IDataFetcher {
     private boolean initialized = false;
     private String yAxisTitle;
 
-    public DataFetcher(DapController dapController, IsmopConverter converter, Levee levee) {
+    public DataFetcher(DapController dapController, Levee levee) {
         this.dapController = dapController;
         this.levee = levee;
         this.contextId = "1";
-        this.converter = converter;
     }
 
     @Override
@@ -292,8 +290,7 @@ public class DataFetcher implements IDataFetcher {
                         series = new ArrayList<DateChartPoint>();
                         results.put(device, series);
                     }
-                    Date date = converter.parse(m.getTimestamp());
-                    series.add(new DateChartPoint(date, m.getValue()));
+                    series.add(new DateChartPoint(m.getTimestamp(), m.getValue()));
                 }
                 callback.series(results);
             }
@@ -321,8 +318,7 @@ public class DataFetcher implements IDataFetcher {
                     public void processMeasurements(List<Measurement> measurements) {
                         List<DateChartPoint> points = new ArrayList<>();
                         for (Measurement m : measurements) {
-                            Date date = converter.parse(m.getTimestamp());
-                            points.add(new DateChartPoint(date, m.getValue()));
+                            points.add(new DateChartPoint(m.getTimestamp(), m.getValue()));
                         }
                         callback.series(points);
                     }

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/FibrePresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/FibrePresenter.java
@@ -11,6 +11,7 @@ import org.moxieapps.gwt.highcharts.client.Series.Type;
 import org.moxieapps.gwt.highcharts.client.events.*;
 import org.moxieapps.gwt.highcharts.client.plotOptions.Marker;
 import org.moxieapps.gwt.highcharts.client.plotOptions.SeriesPlotOptions;
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.IsmopProperties;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
@@ -30,6 +31,8 @@ import static pl.ismop.web.client.widgets.monitoring.fibre.IDataFetcher.*;
 
 @Presenter(view = FibreView.class)
 public class FibrePresenter extends BasePresenter<IFibreView, MainEventBus> implements IFibrePresenter {
+	private final IsmopConverter converter;
+
 	private class DeviceData {
 		private PlotBand plotBand;
 		private Series series;
@@ -67,16 +70,17 @@ public class FibrePresenter extends BasePresenter<IFibreView, MainEventBus> impl
 	private FibreMessages messages;
 
 	@Inject
-	public FibrePresenter(DapController dapController, IsmopProperties properties) {
+	public FibrePresenter(DapController dapController, IsmopProperties properties, IsmopConverter converter) {
 		this.dapController = dapController;
 		this.properties = properties;
+		this.converter = converter;
 	}
 
 	@SuppressWarnings("unused")
 	public void onShowFibrePanel(Levee levee) {
 		if (this.levee != levee) {
 			this.levee = levee;
-			fetcher = new DataFetcher(dapController, levee);
+			fetcher = new DataFetcher(dapController, converter, levee);
 			fetcher.setMock(false);
 		}
 		messages = view.getMessages();

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/FibrePresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/FibrePresenter.java
@@ -31,8 +31,6 @@ import static pl.ismop.web.client.widgets.monitoring.fibre.IDataFetcher.*;
 
 @Presenter(view = FibreView.class)
 public class FibrePresenter extends BasePresenter<IFibreView, MainEventBus> implements IFibrePresenter {
-	private final IsmopConverter converter;
-
 	private class DeviceData {
 		private PlotBand plotBand;
 		private Series series;
@@ -70,17 +68,16 @@ public class FibrePresenter extends BasePresenter<IFibreView, MainEventBus> impl
 	private FibreMessages messages;
 
 	@Inject
-	public FibrePresenter(DapController dapController, IsmopProperties properties, IsmopConverter converter) {
+	public FibrePresenter(DapController dapController, IsmopProperties properties) {
 		this.dapController = dapController;
 		this.properties = properties;
-		this.converter = converter;
 	}
 
 	@SuppressWarnings("unused")
 	public void onShowFibrePanel(Levee levee) {
 		if (this.levee != levee) {
 			this.levee = levee;
-			fetcher = new DataFetcher(dapController, converter, levee);
+			fetcher = new DataFetcher(dapController, levee);
 			fetcher.setMock(false);
 		}
 		messages = view.getMessages();

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/FibrePresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/fibre/FibrePresenter.java
@@ -11,7 +11,6 @@ import org.moxieapps.gwt.highcharts.client.Series.Type;
 import org.moxieapps.gwt.highcharts.client.events.*;
 import org.moxieapps.gwt.highcharts.client.plotOptions.Marker;
 import org.moxieapps.gwt.highcharts.client.plotOptions.SeriesPlotOptions;
-import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.IsmopProperties;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
@@ -22,8 +21,8 @@ import pl.ismop.web.client.dap.section.Section;
 import pl.ismop.web.client.error.ErrorDetails;
 import pl.ismop.web.client.widgets.common.DateChartPoint;
 import pl.ismop.web.client.widgets.common.map.MapPresenter;
-import pl.ismop.web.client.widgets.monitoring.fibre.IFibreView.IFibrePresenter;
 import pl.ismop.web.client.widgets.common.slider.SliderPresenter;
+import pl.ismop.web.client.widgets.monitoring.fibre.IFibreView.IFibrePresenter;
 
 import java.util.*;
 

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/readings/ReadingsPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/readings/ReadingsPresenter.java
@@ -38,7 +38,6 @@ import pl.ismop.web.client.widgets.monitoring.readings.IReadingsView.IReadingsPr
 @Presenter(view = ReadingsView.class)
 public class ReadingsPresenter extends BasePresenter<IReadingsView, MainEventBus> implements IReadingsPresenter {
 	private static final String PICK_VALUE = "pick";
-	private final IsmopConverter converter;
 
 	private DapController dapController;
 	
@@ -59,10 +58,8 @@ public class ReadingsPresenter extends BasePresenter<IReadingsView, MainEventBus
 	private Map<String, Device> additionalDevices;
 
 	@Inject
-	public ReadingsPresenter(DapController dapController, IsmopConverter converter) {
+	public ReadingsPresenter(DapController dapController) {
 		this.dapController = dapController;
-		this.converter = converter;
-
 		series = new ArrayList<>();
 		displayedDevices = new HashMap<>();
 		additionalParameters = new HashMap<>();
@@ -201,8 +198,7 @@ public class ReadingsPresenter extends BasePresenter<IReadingsView, MainEventBus
 											int index = 0;
 											
 											for(Measurement measurement : measurements) {
-												Date date = converter.parse(measurement.getTimestamp());
-												values[index][0] = date.getTime();
+												values[index][0] = measurement.getTimestamp().getTime();
 												values[index][1] = measurement.getValue();
 												index++;
 											}

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/readings/ReadingsPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/readings/ReadingsPresenter.java
@@ -1,27 +1,10 @@
 package pl.ismop.web.client.widgets.monitoring.readings;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Inject;
-
-import com.google.gwt.i18n.client.DateTimeFormat;
-import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
-
-import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
-import pl.ismop.web.client.dap.DapController.ContextsCallback;
-import pl.ismop.web.client.dap.DapController.DevicesCallback;
-import pl.ismop.web.client.dap.DapController.MeasurementsCallback;
-import pl.ismop.web.client.dap.DapController.ParametersCallback;
-import pl.ismop.web.client.dap.DapController.SectionsCallback;
-import pl.ismop.web.client.dap.DapController.TimelinesCallback;
+import pl.ismop.web.client.dap.DapController.*;
 import pl.ismop.web.client.dap.context.Context;
 import pl.ismop.web.client.dap.device.Device;
 import pl.ismop.web.client.dap.levee.Levee;
@@ -34,6 +17,12 @@ import pl.ismop.web.client.widgets.common.chart.ChartPresenter;
 import pl.ismop.web.client.widgets.common.chart.ChartSeries;
 import pl.ismop.web.client.widgets.common.map.MapPresenter;
 import pl.ismop.web.client.widgets.monitoring.readings.IReadingsView.IReadingsPresenter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Presenter(view = ReadingsView.class)
 public class ReadingsPresenter extends BasePresenter<IReadingsView, MainEventBus> implements IReadingsPresenter {

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/readings/ReadingsPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/readings/ReadingsPresenter.java
@@ -13,6 +13,7 @@ import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
 
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
 import pl.ismop.web.client.dap.DapController.ContextsCallback;
@@ -37,7 +38,8 @@ import pl.ismop.web.client.widgets.monitoring.readings.IReadingsView.IReadingsPr
 @Presenter(view = ReadingsView.class)
 public class ReadingsPresenter extends BasePresenter<IReadingsView, MainEventBus> implements IReadingsPresenter {
 	private static final String PICK_VALUE = "pick";
-	
+	private final IsmopConverter converter;
+
 	private DapController dapController;
 	
 	private MapPresenter mapPresenter;
@@ -57,8 +59,10 @@ public class ReadingsPresenter extends BasePresenter<IReadingsView, MainEventBus
 	private Map<String, Device> additionalDevices;
 
 	@Inject
-	public ReadingsPresenter(DapController dapController) {
+	public ReadingsPresenter(DapController dapController, IsmopConverter converter) {
 		this.dapController = dapController;
+		this.converter = converter;
+
 		series = new ArrayList<>();
 		displayedDevices = new HashMap<>();
 		additionalParameters = new HashMap<>();
@@ -197,8 +201,7 @@ public class ReadingsPresenter extends BasePresenter<IReadingsView, MainEventBus
 											int index = 0;
 											
 											for(Measurement measurement : measurements) {
-												DateTimeFormat format = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601);
-												Date date = format.parse(measurement.getTimestamp());
+												Date date = converter.parse(measurement.getTimestamp());
 												values[index][0] = date.getTime();
 												values[index][1] = measurement.getValue();
 												index++;

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/sidepanel/MonitoringSidePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/sidepanel/MonitoringSidePanelPresenter.java
@@ -13,6 +13,7 @@ import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
 
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
 import pl.ismop.web.client.dap.DapController.ContextsCallback;
@@ -36,13 +37,15 @@ import pl.ismop.web.client.widgets.monitoring.sidepanel.IMonitoringSidePanel.IMo
 
 @Presenter(view = MonitoringSidePanelView.class, multiple = true)
 public class MonitoringSidePanelPresenter extends BasePresenter<IMonitoringSidePanel, MainEventBus> implements IMonitoringSidePanelPresenter {
+	private final IsmopConverter converter;
 	private DapController dapController;
 	private Levee selectedLevee;
 	private ChartPresenter chartPresenter;
 
 	@Inject
-	public MonitoringSidePanelPresenter(DapController dapController) {
+	public MonitoringSidePanelPresenter(DapController dapController, IsmopConverter converter) {
 		this.dapController = dapController;
+		this.converter = converter;
 	}
 	
 	public void onLeveeNavigatorReady() {
@@ -221,8 +224,7 @@ public class MonitoringSidePanelPresenter extends BasePresenter<IMonitoringSideP
 														int index = 0;
 														
 														for(Measurement measurement : parameterMeasurements) {
-															DateTimeFormat format = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601);
-															Date date = format.parse(measurement.getTimestamp());
+															Date date = converter.parse(measurement.getTimestamp());
 															values[index][0] = date.getTime();
 															values[index][1] = measurement.getValue();
 															index++;

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/sidepanel/MonitoringSidePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/sidepanel/MonitoringSidePanelPresenter.java
@@ -1,26 +1,10 @@
 package pl.ismop.web.client.widgets.monitoring.sidepanel;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-
-import javax.inject.Inject;
-
-import com.google.gwt.i18n.client.DateTimeFormat;
-import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.mvp4g.client.annotation.Presenter;
 import com.mvp4g.client.presenter.BasePresenter;
-
-import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
-import pl.ismop.web.client.dap.DapController.ContextsCallback;
-import pl.ismop.web.client.dap.DapController.LeveesCallback;
-import pl.ismop.web.client.dap.DapController.MeasurementsCallback;
-import pl.ismop.web.client.dap.DapController.ParametersCallback;
-import pl.ismop.web.client.dap.DapController.TimelinesCallback;
+import pl.ismop.web.client.dap.DapController.*;
 import pl.ismop.web.client.dap.context.Context;
 import pl.ismop.web.client.dap.device.Device;
 import pl.ismop.web.client.dap.deviceaggregation.DeviceAggregate;
@@ -34,6 +18,12 @@ import pl.ismop.web.client.error.ErrorDetails;
 import pl.ismop.web.client.widgets.common.chart.ChartPresenter;
 import pl.ismop.web.client.widgets.common.chart.ChartSeries;
 import pl.ismop.web.client.widgets.monitoring.sidepanel.IMonitoringSidePanel.IMonitoringSidePanelPresenter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 @Presenter(view = MonitoringSidePanelView.class, multiple = true)
 public class MonitoringSidePanelPresenter extends BasePresenter<IMonitoringSidePanel, MainEventBus> implements IMonitoringSidePanelPresenter {

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/sidepanel/MonitoringSidePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/sidepanel/MonitoringSidePanelPresenter.java
@@ -37,15 +37,13 @@ import pl.ismop.web.client.widgets.monitoring.sidepanel.IMonitoringSidePanel.IMo
 
 @Presenter(view = MonitoringSidePanelView.class, multiple = true)
 public class MonitoringSidePanelPresenter extends BasePresenter<IMonitoringSidePanel, MainEventBus> implements IMonitoringSidePanelPresenter {
-	private final IsmopConverter converter;
 	private DapController dapController;
 	private Levee selectedLevee;
 	private ChartPresenter chartPresenter;
 
 	@Inject
-	public MonitoringSidePanelPresenter(DapController dapController, IsmopConverter converter) {
+	public MonitoringSidePanelPresenter(DapController dapController) {
 		this.dapController = dapController;
-		this.converter = converter;
 	}
 	
 	public void onLeveeNavigatorReady() {
@@ -224,8 +222,7 @@ public class MonitoringSidePanelPresenter extends BasePresenter<IMonitoringSideP
 														int index = 0;
 														
 														for(Measurement measurement : parameterMeasurements) {
-															Date date = converter.parse(measurement.getTimestamp());
-															values[index][0] = date.getTime();
+															values[index][0] = measurement.getTimestamp().getTime();
 															values[index][1] = measurement.getValue();
 															index++;
 														}

--- a/src/main/java/pl/ismop/web/client/widgets/monitoring/weather/WeatherStationPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/monitoring/weather/WeatherStationPresenter.java
@@ -192,9 +192,7 @@ public class WeatherStationPresenter extends BasePresenter<IWeatherStationView, 
 				
 				for(Measurement measurement : measurements) {
 					if(timelineId.equals(measurement.getTimelineId())) {
-						DateTimeFormat format = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601);
-						Date date = format.parse(measurement.getTimestamp());
-						values[index][0] = date.getTime();
+						values[index][0] = measurement.getTimestamp().getTime();
 						values[index][1] = measurement.getValue();
 						
 						if(index == measurementCount - 1) {
@@ -202,7 +200,7 @@ public class WeatherStationPresenter extends BasePresenter<IWeatherStationView, 
 							Device device = findDevice(deviceMap, parameter.getId());
 							LatestReading latestReading = new LatestReading();
 							latestReading.label = parameter.getMeasurementTypeName();
-							latestReading.timestamp = date;
+							latestReading.timestamp = measurement.getTimestamp();
 							latestReading.unit = parameter.getMeasurementTypeUnit();
 							latestReading.value = measurement.getValue();
 							

--- a/src/main/java/pl/ismop/web/client/widgets/old/experiment/ExperimentPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/old/experiment/ExperimentPresenter.java
@@ -78,9 +78,7 @@ public class ExperimentPresenter extends BasePresenter<IExperimentView, MainEven
 		builder.append("aa|").append(yLabel).append("\n");
 		
 		for(Measurement measurement : measurements) {
-			DateTimeFormat format = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601);
-			Date date = format.parse(measurement.getTimestamp());
-			date = new Date(date.getTime() - 7200000);
+			Date date = new Date(measurement.getTimestamp().getTime() - 7200000);
 			builder.append(DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(date))
 					.append("|")
 					.append(measurement.getValue())

--- a/src/main/java/pl/ismop/web/client/widgets/old/maps/google/GoogleMapsPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/old/maps/google/GoogleMapsPresenter.java
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 import com.mvp4g.client.annotation.EventHandler;
 import com.mvp4g.client.event.BaseEventHandler;
 
+import pl.ismop.web.client.IsmopConverter;
 import pl.ismop.web.client.MainEventBus;
 import pl.ismop.web.client.dap.DapController;
 import pl.ismop.web.client.dap.DapController.DeviceAggregatesCallback;
@@ -48,7 +49,8 @@ import pl.ismop.web.client.widgets.old.newexperiment.ThreatAssessmentPresenter;
 @EventHandler
 public class GoogleMapsPresenter extends BaseEventHandler<MainEventBus> {
 	private static final Logger log = LoggerFactory.getLogger(GoogleMapsPresenter.class);
-	
+	private final IsmopConverter converter;
+
 	private DapController dapController;
 	private String elementId;
 	private MapMessages messages;
@@ -70,10 +72,12 @@ public class GoogleMapsPresenter extends BaseEventHandler<MainEventBus> {
 	private List<String> aggregateFeatureIds;
 
 	@Inject
-	public GoogleMapsPresenter(DapController dapController, MapMessages messages, GeoJsonFeaturesEncDec jsonFeaturesEncDec) {
+	public GoogleMapsPresenter(DapController dapController, MapMessages messages,
+							   GeoJsonFeaturesEncDec jsonFeaturesEncDec, IsmopConverter converter) {
 		this.dapController = dapController;
 		this.messages = messages;
 		this.jsonFeaturesEncDec = jsonFeaturesEncDec;
+		this.converter = converter;
 		sections = new HashMap<>();
 		sectionColors = new HashMap<>();
 		sectionColors.put("none", "#D9EDF7");
@@ -371,7 +375,7 @@ public class GoogleMapsPresenter extends BaseEventHandler<MainEventBus> {
 							double max = Double.MIN_VALUE;
 							
 							for(Measurement measurement : measurements) {
-								push(measurement.getValue(), measurement.getTimestamp(), values);
+								push(measurement.getValue(), converter.format(measurement.getTimestamp()), values);
 								
 								if(measurement.getValue() < min) {
 									min = measurement.getValue();
@@ -441,9 +445,7 @@ public class GoogleMapsPresenter extends BaseEventHandler<MainEventBus> {
 		builder.append("aa|").append(yLabel).append("\n");
 		
 		for(Measurement measurement : measurements) {
-			DateTimeFormat format = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601);
-			Date date = format.parse(measurement.getTimestamp());
-			date = new Date(date.getTime() - 7200000);
+			Date date = new Date(measurement.getTimestamp().getTime() - 7200000);
 			builder.append(DateTimeFormat.getFormat(PredefinedFormat.ISO_8601).format(date))
 					.append("|")
 					.append(measurement.getValue())

--- a/src/main/java/pl/ismop/web/client/widgets/old/plot/PlotPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/old/plot/PlotPresenter.java
@@ -213,9 +213,7 @@ public class PlotPresenter extends BasePresenter<IPlotView, MainEventBus> implem
 				
 				for(Measurement measurement : measurements) {
 					if(measurement.getTimelineId().equals(timeline.getId())) {
-						DateTimeFormat format = DateTimeFormat.getFormat(PredefinedFormat.ISO_8601);
-						Date date = format.parse(measurement.getTimestamp());
-						measurementValues[index][0] = date.getTime();
+						measurementValues[index][0] = measurement.getTimestamp().getTime();
 						measurementValues[index][1] = measurement.getValue();
 						index++;
 					}


### PR DESCRIPTION
DAP DAO objects date fields was changed from `String` into `Date`. This allowed to remove a lot of code responsible for data formatting. What is more I introduced `IsmopConverter` object, which is responsible for conversion between `Date` and `String`.