### PR TITLE
Show only visible devices

### DIFF
--- a/src/main/java/pl/ismop/web/client/dap/device/DeviceService.java
+++ b/src/main/java/pl/ismop/web/client/dap/device/DeviceService.java
@@ -13,32 +13,32 @@ import pl.ismop.web.client.dap.DapDispatcher;
 @Options(dispatcher = DapDispatcher.class, serviceRootKey = "dap")
 public interface DeviceService extends RestService {
 	@GET
-	@Path("devices?device_aggregation_id={deviceAggregationIdFilter}")
+	@Path("devices?device_aggregation_id={deviceAggregationIdFilter}&visible=true")
 	void getDevices(@PathParam("deviceAggregationIdFilter") String deviceAggregationIdFilter, MethodCallback<DevicesResponse> callback);
 
 	@GET
-	@Path("devices?device_type={deviceType}")
+	@Path("devices?device_type={deviceType}&visible=true")
 	void getDevicesForType(@PathParam("deviceType") String deviceType, MethodCallback<DevicesResponse> methodCallback);
 
 	@GET
-	@Path("devices?device_type={deviceType}&section_id={sectionId}")
+	@Path("devices?device_type={deviceType}&section_id={sectionId}&visible=true")
 	void getDevicesForTypeAndSectionId(@PathParam("deviceType") String deviceType, @PathParam("sectionId") String sectionId,
 			MethodCallback<DevicesResponse> methodCallback);
 
 	@GET
-	@Path("devices?section_id={sectionId}")
+	@Path("devices?section_id={sectionId}&visible=true")
 	void getDevicesForSectionId(@PathParam("sectionId") String sectionId, MethodCallback<DevicesResponse> methodCallback);
 
 	@GET
-	@Path("devices?section_id={sectionId}&device_type={deviceType}")
+	@Path("devices?section_id={sectionId}&device_type={deviceType}&visible=true")
 	void getDevicesForSectionIdAndType(@PathParam("sectionId") String sectionId, @PathParam("deviceType") String deviceType,
 			MethodCallback<DevicesResponse> methodCallback);
 
 	@GET
-	@Path("devices?id={idFilter}")
+	@Path("devices?id={idFilter}&visible=true")
 	void getDevicesForIds(@PathParam("idFilter") String idFilter, MethodCallback<DevicesResponse> methodCallback);
 
 	@GET
-	@Path("devices?levee_id={leveeId}")
+	@Path("devices?levee_id={leveeId}&visible=true")
 	void getLeveeDevices(@PathParam("leveeId") Integer leveeId, MethodCallback<DevicesResponse> methodCallback);
 }


### PR DESCRIPTION
Show only visible devices on all eitwid views. 

@dharezlak please let me know if there can be any problem with it. Currently only old fiber has visible set to `false`. 