### PR TITLE
Fix water height on realtime view

### DIFF
--- a/src/main/java/pl/ismop/web/client/widgets/realtime/main/RealTimePanelPresenter.java
+++ b/src/main/java/pl/ismop/web/client/widgets/realtime/main/RealTimePanelPresenter.java
@@ -449,8 +449,8 @@ public class RealTimePanelPresenter extends BasePresenter<IRealTimePanelView, Ma
 					@SuppressWarnings("unchecked")
 					List<Parameter> parameters = (List<Parameter>) resultList.get(1);
 					waterLevelParameter = Iterables.find(parameters,
-							p -> p.getParameterName()
-								.equals("Monitorowanie wysokości fali - Level1_PV"));
+							p -> p.getCustomId()
+								.equals("pumpMonitoring.ASP_Level2_PV"));
 					
 					if (contexts.size() > 0 && parameters.size() > 0) {
 						return dapController.getTimelinesForParameterIds(


### PR DESCRIPTION
Water height was fetched from DAP using its name and lately this name was changed. Now custom id is used instead of name (it is less likely to be changed in the future). What is more average value was taken.

/cc @nowakowski, @mpawlik 